### PR TITLE
feat: ability to supply config to `HttpCacheManager.init()`

### DIFF
--- a/lib/src/cache_manager/http_cache_manager.dart
+++ b/lib/src/cache_manager/http_cache_manager.dart
@@ -5,8 +5,6 @@ import 'package:flutter/foundation.dart';
 import 'package:http_cache_stream/src/cache_manager/http_cache_server.dart';
 import 'package:http_cache_stream/src/models/config/stream_cache_config.dart';
 import 'package:http_cache_stream/src/models/metadata/cache_files.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
 
 import '../../http_cache_stream.dart';
 import '../etc/const.dart';
@@ -136,7 +134,7 @@ class HttpCacheManager {
     return '${uri.path}?${uri.query}';
   }
 
-  static Future<HttpCacheManager> init({Directory? cacheDir}) async {
+  static Future<HttpCacheManager> init({GlobalCacheConfig? config}) async {
     if (_instance != null) {
       return instance;
     }
@@ -145,14 +143,11 @@ class HttpCacheManager {
     }
     _initCompleter = Completer<HttpCacheManager>();
     try {
-      cacheDir ??= Directory(
-        p.join((await getTemporaryDirectory()).path, _kCacheDirName),
-      );
-      final httpCacheConfig = GlobalCacheConfig(cacheDir);
+      config ??= await DefaultGlobalCacheConfig.create();
       final httpCacheServer = await HttpCacheServer.init();
       final httpCacheManager = HttpCacheManager._(
         httpCacheServer,
-        httpCacheConfig,
+        config,
       );
       _instance = httpCacheManager;
       _initCompleter!.complete(httpCacheManager);
@@ -178,5 +173,3 @@ class HttpCacheManager {
   static HttpCacheManager? _instance;
   static bool get isInitialized => _instance != null;
 }
-
-const _kCacheDirName = 'http_cache_stream';

--- a/lib/src/models/config/cache_config.dart
+++ b/lib/src/models/config/cache_config.dart
@@ -1,5 +1,8 @@
 import 'dart:io';
 
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart' as pp;
+
 abstract interface class CacheConfiguration {
   ///Custom headers to be sent when downloading cache.
   Map<String, Object> get requestHeaders;
@@ -86,6 +89,10 @@ sealed class CacheConfig implements CacheConfiguration {
   int _minChunkSize = 1024 * 64; // 64KB
 }
 
+class LocalCacheConfig extends CacheConfig {
+  LocalCacheConfig();
+}
+
 class GlobalCacheConfig extends CacheConfig {
   ///The directory where the cache is stored. This can only be set during initialization.
   /// The cache directory must be writable and accessible by the application.
@@ -94,6 +101,14 @@ class GlobalCacheConfig extends CacheConfig {
   GlobalCacheConfig(this.cacheDirectory);
 }
 
-class LocalCacheConfig extends CacheConfig {
-  LocalCacheConfig();
+class DefaultGlobalCacheConfig extends GlobalCacheConfig {
+  DefaultGlobalCacheConfig._(super.cacheDirectory);
+
+  static const _kCacheDirName = 'http_cache_stream';
+
+  static Future<DefaultGlobalCacheConfig> create() async {
+    final appTempDirectory = (await pp.getTemporaryDirectory()).path;
+    final cacheDirPath = p.join(appTempDirectory, _kCacheDirName);
+    return DefaultGlobalCacheConfig._(Directory(cacheDirPath));
+  }
 }


### PR DESCRIPTION
### API feature

instead of just specifying `cacheDir` in `HttpCacheManager.init()`, a config should be passed, this allows max configuration with the ability to provide custom cache config (extending `GlobalCacheConfig`)

example:
```dart
class MyCustomCacheConfig extends GlobalCacheConfig {
  MyCustomCacheConfig() : super(Directory(''));

  @override
  int? get rangeRequestSplitThreshold => 1 * 1024 * 1024; // 1 MB
}

void main() async {
  HttpCacheManager.init(config: MyCustomCacheConfig());
}
```


thanks for the awesome package btw!! it solved a really big issue for me 💗