### PR TITLE
feat: `HttpCacheStream.onCacheDone()` callback

### DIFF
--- a/lib/src/cache_manager/http_cache_manager.dart
+++ b/lib/src/cache_manager/http_cache_manager.dart
@@ -22,7 +22,7 @@ class HttpCacheManager {
   ///Create a [HttpCacheStream] instance for the given URL. If an instance already exists, the existing instance will be returned.
   ///
   ///Use [File] to specify the output file to save the downloaded content to. If not provided, a file will be created in the cache directory (recommended).
-  HttpCacheStream createStream(Uri sourceUrl, {File? file}) {
+  HttpCacheStream createStream(Uri sourceUrl, {File? file, void Function(File cachedFile)? onCacheDone}) {
     final key = _requestKey(sourceUrl);
     HttpCacheStream? httpCacheStream = _streams[key];
     if (httpCacheStream != null) {
@@ -35,6 +35,7 @@ class HttpCacheManager {
         cacheUrl,
         cacheFiles,
         StreamCacheConfig(config),
+        onCacheDone: onCacheDone,
       );
       httpCacheStream.future.whenComplete(
         () => _streams.remove(key),

--- a/lib/src/cache_stream/http_cache_stream.dart
+++ b/lib/src/cache_stream/http_cache_stream.dart
@@ -21,6 +21,9 @@ class HttpCacheStream {
   ///The Url of the cached stream (e.g., http://127.0.0.1:8080/file.mp3)
   final Uri cacheUrl;
 
+  ///A callback to be called the first time a stream is fully cached.
+  final void Function(File cachedFile)? onCacheDone;
+
   final CacheFiles _cacheFiles;
 
   final StreamCacheConfig config;
@@ -39,8 +42,9 @@ class HttpCacheStream {
     this.sourceUrl,
     this.cacheUrl,
     this._cacheFiles,
-    this.config,
-  ) {
+    this.config, {
+    this.onCacheDone,
+  }) {
     final cachedHeaders = metadata.headers;
     if (cachedHeaders == null || cachedHeaders.sourceLength == null) return;
     if (_updateCacheProgress() == 1.0 && config.validateOutdatedCache && cachedHeaders.shouldRevalidate()) {
@@ -153,6 +157,7 @@ class HttpCacheStream {
               );
             }
             await metadata.partialCacheFile.rename(cacheFile.path);
+            onCacheDone?.call(cacheFile);
           },
           onProgress: (percentage) {
             //Limit to 99% to prevent 100% progress before write is complete


### PR DESCRIPTION
very useful callback when a stream is cached for the first time, could be used for example to add the cache entry to a db/hashmap/etc

example

```dart
final cacheStream = HttpCacheManager.instance.createStream(
  uri,
  file: cacheFile,
  onCacheDone: (cachedFile) {
    // use the cached file
    _cachedItemsMap[uri] = cachedFile;
  },
);
```