### PR TITLE
fix: file locked while renaming file on some platforms like windows

### DIFF
--- a/lib/src/cache_stream/cache_downloader/cache_downloader.dart
+++ b/lib/src/cache_stream/cache_downloader/cache_downloader.dart
@@ -100,6 +100,9 @@ class CacheDownloader {
               _sourceLength ??=
                   (_downloader.isDone ? _downloader.position : null);
           if (bufferedCacheLength == sourceLength) {
+            await _sink.close();
+            await _streamController.close();
+            await cancel();
             await onComplete();
           } else if (bufferedCacheLength != downloadPosition) {
             throw InvalidCacheLengthException(
@@ -115,6 +118,7 @@ class CacheDownloader {
           }
           _sink.close().ignore();
           _streamController.close().ignore();
+          cancel().ignore();
         });
   }
 


### PR DESCRIPTION
the file io sink needs to be closed before renaming/doing any other operation on the file

